### PR TITLE
Fix solr config

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -9,4 +9,6 @@ services:
   solrindex:
     type: solr:6.6
     portforward: 9999
-    core: drupal_search
+    core: collection1
+    config:
+      conf: docroot/modules/contrib/search_api_solr/solr-conf/6.x

--- a/config/base/search_api.server.drupal_search.yml
+++ b/config/base/search_api.server.drupal_search.yml
@@ -15,12 +15,12 @@ backend_config:
     host: solrindex
     port: '8983'
     path: /solr
-    core: drupal_search
+    core: collection1
     timeout: 5
     index_timeout: 5
     optimize_timeout: 10
     commit_within: 1000
-    solr_version: '6'
+    solr_version: ''
     http_method: AUTO
   retrieve_data: false
   highlight_data: false


### PR DESCRIPTION
@americkson I needed to make these changes to get solr working for me.

- Didn't seem to like `drupal_seacrh` for a core name. Maybe the underscore is invalid?
- Needed to provide the path to the search_api_solr config for the schema.